### PR TITLE
bug fix #10: set host header for CONNECT request.

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -106,7 +106,10 @@ TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
   var connectOptions = mergeOptions({}, self.proxyOptions, {
     method: 'CONNECT',
     path: options.host + ':' + options.port,
-    agent: false
+    agent: false,
+    headers: {
+      host: options.host + ':' + options.port
+    }
   });
   if (connectOptions.proxyAuth) {
     connectOptions.headers = connectOptions.headers || {};


### PR DESCRIPTION
Fix issue #10 .

Set Host header for CONNECT request in TunnelingAgent.createSocket().