### PR TITLE
Use `Buffer.from` instead of `new Buffer`

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -119,7 +119,7 @@ TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
   if (connectOptions.proxyAuth) {
     connectOptions.headers = connectOptions.headers || {};
     connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
-        new Buffer(connectOptions.proxyAuth).toString('base64');
+        Buffer.from(connectOptions.proxyAuth).toString('base64');
   }
 
   debug('making CONNECT request');


### PR DESCRIPTION
`new Buffer` has been [deprecated since Node v6.0.0](https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding)

When this lib is bundled with zero-dependencies, e.g. in a serverless function like AWS lambda, this code emits a deprecation warning.

Not a huge deal but figured it might be nice to update it.

`Buffer.from` was [added in Node v5.10.0](https://nodejs.org/api/buffer.html#buffer_static_method_buffer_from_string_encoding) so this probably counts as a major version bump since it will break apps running Node < v5.10.0